### PR TITLE
fix: Using $var[$idx] instead of $var{$idx} on OLE.php

### DIFF
--- a/OLE.php
+++ b/OLE.php
@@ -469,7 +469,7 @@ class OLE
     {
         $rawname = '';
         for ($i = 0; $i < strlen($ascii); $i++) {
-            $rawname .= $ascii{$i} . "\x00";
+            $rawname .= $ascii[$i] . "\x00";
         }
         return $rawname;
     }
@@ -538,14 +538,14 @@ class OLE
         $factor = pow(2,32);
         $high_part = 0;
         for ($i = 0; $i < 4; $i++) {
-            list(, $high_part) = unpack('C', $string{(7 - $i)});
+            list(, $high_part) = unpack('C', $string[(7 - $i)]);
             if ($i < 3) {
                 $high_part *= 0x100;
             }
         }
         $low_part = 0;
         for ($i = 4; $i < 8; $i++) {
-            list(, $low_part) = unpack('C', $string{(7 - $i)});
+            list(, $low_part) = unpack('C', $string[(7 - $i)]);
             if ($i < 7) {
                 $low_part *= 0x100;
             }


### PR DESCRIPTION
$var{$idx} was deprecated in PHP version 7.4 and removed in PHP version 8.